### PR TITLE
FIX: Properly support ES Module loading in Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bin": {
     "formulize-mcp": "./dist/formulize-mcp.js"
   },
+  "type": "module",
   "files": [
     "dist/**/*",
     "README.md",


### PR DESCRIPTION
Node complains when trying to load ES modules when the `type` attribute is missing from package.json